### PR TITLE
Rename Object to BaseObject.

### DIFF
--- a/base/MaterialIcons.php
+++ b/base/MaterialIcons.php
@@ -2,7 +2,7 @@
 
 namespace yii\materialicons\base;
 
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\materialicons\component\Icon;
 use yii\materialicons\component\Stack;
 
@@ -11,7 +11,7 @@ use yii\materialicons\component\Stack;
  * Class MaterialIcons
  * @package yii\materialicons\base
  */
-abstract class MaterialIcons extends Object
+abstract class MaterialIcons extends BaseObject
 {
     /**
      * @param string $name

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=5.4.0",
         "yiisoft/yii2": "*",
-        "mervick/material-design-icons": "~1.0"
+        "mervick/material-design-icons": "2.2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
"since 2.0.13, the class name `Object` is invalid since PHP 7.2, use [[BaseObject]] instead."